### PR TITLE
Resort files in root directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - release
+      - beta
 
   workflow_dispatch:
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,7 @@
   "branches": [
     "main",
     {
-      "name": "release",
+      "name": "beta",
       "prerelease": true
     }
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.0.10-beta.1](https://github.com/mcarvin8/xml-disassembler/compare/v1.0.9...v1.0.10-beta.1) (2024-03-07)
+
+### Bug Fixes
+
+- sort files based on name in root path ([f21c989](https://github.com/mcarvin8/xml-disassembler/commit/f21c989e29c08b7f32913a507cc2d1540feb8549))
+
 ## [1.0.9](https://github.com/mcarvin8/xml-disassembler/compare/v1.0.8...v1.0.9) (2024-03-07)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM](https://img.shields.io/npm/v/xml-disassembler.svg?label=xml-disassembler)](https://www.npmjs.com/package/xml-disassembler) [![Downloads/week](https://img.shields.io/npm/dw/xml-disassembler.svg)](https://npmjs.org/package/xml-disassembler)
 
-A TS package to disassemble XML files into smaller, more manageable files and re-assemble them when needed.
+A JavaScript package to disassemble XML files into smaller, more manageable files and re-assemble them when needed.
 
 ## Background
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xml-disassembler",
   "version": "1.0.9",
-  "description": "A package to disassemble XML files into smaller, more manageable files and reassemble them when needed.",
+  "description": "A JavaScript package to disassemble XML files into smaller, more manageable files and reassemble them when needed.",
   "author": "Matt Carvin",
   "license": "ISC",
   "main": "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xml-disassembler",
-  "version": "1.0.9",
+  "version": "1.0.10-beta.1",
   "description": "A JavaScript package to disassemble XML files into smaller, more manageable files and reassemble them when needed.",
   "author": "Matt Carvin",
   "license": "ISC",

--- a/src/service/reassembleXMLFileHandler.ts
+++ b/src/service/reassembleXMLFileHandler.ts
@@ -85,6 +85,14 @@ export class ReassembleXMLFileHandler {
     }
     // Process files directly inside the `xmlPath` directory
     const filesInxmlPath = await fs.readdir(xmlPath);
+
+    // Sort files based on the name
+    filesInxmlPath.sort((fileA, fileB) => {
+      const fullNameA = fileA.split(".")[0].toLowerCase();
+      const fullNameB = fileB.split(".")[0].toLowerCase();
+      return fullNameA.localeCompare(fullNameB);
+    });
+
     for (const file of filesInxmlPath) {
       const filePath = path.join(xmlPath, file);
       const fileStat = await fs.stat(filePath);


### PR DESCRIPTION
This solves a weird issue I've seen in the https://github.com/mcarvin8/sfdx-decomposer-plugin where the Reassembled Files would have different sorting in Windows versus Ubuntu (what my CI/CD job image is).

The reassemble would process files in the root directory (folder and the root meta file) in a different order on Windows versus Ubuntu. The unit test in SFDX decomposer which compares baseline reassembled files to reassemble files under test passed locally on my Windows machine, which allowed me to push the code to GitHub. However, once the GitHub ran in a Ubuntu container, the same test would fail consistently due to the sorting of the reassembled file. The same file contents, but the reassembled meta file would be at the top of the file in Linux over being at the bottom of the file in Windows.

Adding the sort function to the root directory fixes this issue after pushing this beta build and installing it in the SFDX decomposer. This allows me to un-install fast-xml-parser from that repo since I only needed to run it directly for the compare test.