### PR TITLE
refactor: extract resolveNativeDir helper for full branch coverage

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -7,9 +7,12 @@ function esmNativeLoader() {
     name: "esm-native-loader",
     renderChunk(code, chunk, options) {
       if (options.format !== "es") return null;
-      // Match: const isDist = ... const nativeDir = ... const nativeAddon = require(path.join(nativeDir, "index.node"));
+      // Match the inlined resolveNativeDir helper through the nativeAddon require.
+      // Covers both the function declaration and the module-level consumers,
+      // replacing the whole block with an ESM-safe equivalent that hardcodes
+      // the dist path (ESM builds only ship inside dist/).
       const block =
-        /const\s+isDist\s*=[\s\S]*?const\s+nativeAddon\s*=\s*require\s*\(\s*path\.join\s*\(\s*nativeDir\s*,\s*["']index\.node["']\s*\)\s*\)\s*;?/;
+        /function\s+resolveNativeDir[\s\S]*?const\s+nativeAddon\s*=\s*require\s*\(\s*path\.join\s*\(\s*nativeDir\s*,\s*["']index\.node["']\s*\)\s*\)\s*;?/;
       if (!block.test(code)) return null;
       const newCode = code
         .replace(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,11 @@
 import path from "path";
+import { resolveNativeDir } from "./native-dir";
 
-// Platform-specific path so one npm package can ship win/linux/darwin binaries
-const isDist = path.basename(__dirname) === "dist";
-const nativeDir = isDist
-  ? path.join(__dirname, "native", process.platform + "-" + process.arch)
-  : path.join(
-      __dirname,
-      "..",
-      "dist",
-      "native",
-      process.platform + "-" + process.arch,
-    );
+const nativeDir = resolveNativeDir(
+  __dirname,
+  process.platform,
+  process.arch,
+);
 const nativeAddon = require(path.join(nativeDir, "index.node"));
 
 export class DisassembleXMLFileHandler {

--- a/src/native-dir.ts
+++ b/src/native-dir.ts
@@ -1,0 +1,20 @@
+import path from "path";
+
+/**
+ * Resolve the platform-specific directory that contains the native Rust addon.
+ *
+ * Exported from its own module (instead of `index.ts`) so it can be unit-tested
+ * without being part of the public package API. The rollup ESM plugin replaces
+ * the call site in `index.ts` at build time, so this function only executes
+ * when the package is consumed as CJS or when tests import it directly.
+ */
+export function resolveNativeDir(
+  baseDir: string,
+  platform: string,
+  arch: string,
+): string {
+  const isDist = path.basename(baseDir) === "dist";
+  return isDist
+    ? path.join(baseDir, "native", `${platform}-${arch}`)
+    : path.join(baseDir, "..", "dist", "native", `${platform}-${arch}`);
+}

--- a/test/native-dir.spec.ts
+++ b/test/native-dir.spec.ts
@@ -1,0 +1,36 @@
+import { strictEqual } from "assert";
+import path from "path";
+import { resolveNativeDir } from "../src/native-dir";
+
+describe("resolveNativeDir", () => {
+  it("resolves to <baseDir>/native/<platform>-<arch> when baseDir is the built dist folder", () => {
+    const result = resolveNativeDir(
+      path.join("some", "pkg", "dist"),
+      "linux",
+      "x64",
+    );
+    strictEqual(result, path.join("some", "pkg", "dist", "native", "linux-x64"));
+  });
+
+  it("resolves to ../dist/native/<platform>-<arch> when baseDir is the source folder (dev/test)", () => {
+    const result = resolveNativeDir(
+      path.join("some", "pkg", "src"),
+      "darwin",
+      "arm64",
+    );
+    strictEqual(
+      result,
+      path.join("some", "pkg", "src", "..", "dist", "native", "darwin-arm64"),
+    );
+  });
+
+  it("uses the baseDir's basename to determine the branch (not the full path)", () => {
+    const distResult = resolveNativeDir("/tmp/dist", "win32", "x64");
+    const srcResult = resolveNativeDir("/tmp/src", "win32", "x64");
+    strictEqual(distResult, path.join("/tmp/dist", "native", "win32-x64"));
+    strictEqual(
+      srcResult,
+      path.join("/tmp/src", "..", "dist", "native", "win32-x64"),
+    );
+  });
+});


### PR DESCRIPTION
Move the platform-specific native addon path logic out of src/index.ts into src/native-dir.ts so it can be unit-tested in isolation. The previous inline ternary was unreachable from tests (its `isDist=true` branch only fires when the package runs from dist/ after publish), leaving branch coverage stuck at 50%.

The rollup ESM loader regex is updated to match the new bundled shape; the ESM output is unchanged functionally and now also tree-shakes the helper out of dist/index.mjs.